### PR TITLE
Minor style fix to a test suite

### DIFF
--- a/tests/evaluation_suite_glue_ci.py
+++ b/tests/evaluation_suite_glue_ci.py
@@ -3,7 +3,6 @@ from evaluate.evaluation_suite import SubTask
 
 
 class Suite(evaluate.EvaluationSuite):
-
     def __init__(self, name):
         super().__init__(name)
 
@@ -19,11 +18,8 @@ class Suite(evaluate.EvaluationSuite):
                     "input_column": "sentence",
                     "label_column": "label",
                     "config_name": "sst2",
-                    "label_mapping": {
-                        "NEGATIVE": 0.0,
-                        "POSITIVE": 1.0
-                    }
-                }
+                    "label_mapping": {"NEGATIVE": 0.0, "POSITIVE": 1.0},
+                },
             ),
             SubTask(
                 task_type="text-classification",
@@ -36,10 +32,7 @@ class Suite(evaluate.EvaluationSuite):
                     "second_input_column": "question2",
                     "label_column": "label",
                     "config_name": "qqp",
-                    "label_mapping": {
-                        "NEGATIVE": 0.0,
-                        "POSITIVE": 1.0
-                    }
-                }
-            )
+                    "label_mapping": {"NEGATIVE": 0.0, "POSITIVE": 1.0},
+                },
+            ),
         ]


### PR DESCRIPTION
To test this fix try this:
```bash
$ virtualenv -p python3.10 /tmp/.venv310
$ . /tmp/.venv310/bin/activate


$ black --diff --color --line-length 119 --target-version py36 tests src metrics comparisons measurements
All done! ✨ 🍰 ✨
179 files would be left unchanged.
```